### PR TITLE
Fix performance issues when loading many .TextGrid files

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,0 @@
-allowed-duplicate-crates = ["syn"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "textgridde-rs"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "derive_more",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textgridde-rs"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2021"
 description = "A library for dealing with Praat TextGrid files. MIT licensed."
 authors = ["Caleb Long <cmlong02@outlook.com>"]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,10 @@
-use std::{fs::File, io::Read, path::PathBuf};
+use std::{
+    fs::File,
+    io::{BufReader, Read, Result},
+    path::PathBuf,
+};
+
+use encoding_rs::Encoding;
 
 pub enum Source {
     Path(PathBuf),
@@ -6,24 +12,6 @@ pub enum Source {
     StringVector(Vec<String>),
     Stream(Box<dyn Read>),
     File(File),
-}
-
-impl From<PathBuf> for Source {
-    fn from(path: PathBuf) -> Self {
-        Self::Path(path)
-    }
-}
-
-impl From<&str> for Source {
-    fn from(str: &str) -> Self {
-        Self::String(str.to_string())
-    }
-}
-
-impl From<String> for Source {
-    fn from(string: String) -> Self {
-        Self::String(string)
-    }
 }
 
 impl From<Vec<String>> for Source {
@@ -43,14 +31,139 @@ impl From<Vec<&str>> for Source {
     }
 }
 
-impl From<Box<dyn Read>> for Source {
-    fn from(stream: Box<dyn Read>) -> Self {
-        Self::Stream(stream)
+impl From<String> for Source {
+    fn from(string: String) -> Self {
+        Self::String(string)
+    }
+}
+
+impl From<&str> for Source {
+    fn from(str: &str) -> Self {
+        Self::String(str.to_string())
+    }
+}
+
+impl From<PathBuf> for Source {
+    fn from(path: PathBuf) -> Self {
+        Self::Path(path)
     }
 }
 
 impl From<File> for Source {
     fn from(file: File) -> Self {
         Self::File(file)
+    }
+}
+
+impl From<Box<dyn Read>> for Source {
+    fn from(stream: Box<dyn Read>) -> Self {
+        Self::Stream(stream)
+    }
+}
+
+/// Gets the content of a file or stream.
+///
+/// # Arguments
+///
+/// * `source` - One of the following:
+///     * `Source::StringVector` - A vector of strings (what every other source is converted to).
+///     * `Source::Stream` - A stream of text (what path/file is converted to).
+///     * `Source::String` - A string that may be a path to a file or the content itself.
+///     * `Source::Path` - A path to a file.
+///     * `Source::File` - A file.
+/// * `name` - The file name; only passed during recursion.
+///
+/// # Returns
+///
+/// A `Result` containing a tuple of a vector of strings and a string if successful, or an `std::io::Error` if parsing failed.
+pub fn get_file_content(source: Source, name: Option<String>) -> Result<(Vec<String>, String)> {
+    match source {
+        Source::StringVector(string_vector) => {
+            Ok((string_vector, name.unwrap_or("New TextGrid".to_string())))
+        }
+        Source::String(string) => {
+            if PathBuf::from(&string).is_file() {
+                return get_file_content(Source::Path(string.into()), None);
+            }
+            let content = string
+                .split('\n')
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<String>>();
+            let name = "New TextGrid".to_string();
+
+            get_file_content(Source::StringVector(content), Some(name))
+        }
+        Source::Stream(mut stream) => {
+            // Use encoding_rs to detect the BOM and convert to UTF-8 if necessary, since TextGrid files can sometimes be encoded in UTF-16.
+
+            let mut buffer = Vec::new();
+            stream.read_to_end(&mut buffer)?;
+
+            let (encoding, _) = Encoding::for_bom(&buffer).unwrap_or((encoding_rs::UTF_8, 0));
+            let content = encoding.decode(&buffer).0;
+
+            let content = content
+                .split('\n')
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<String>>();
+
+            get_file_content(
+                Source::StringVector(content),
+                Some(name.unwrap_or("New TextGrid".to_string())),
+            )
+        }
+        Source::Path(path) => {
+            let file = File::open(path.clone())?;
+            let name = path
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new("New Textgrid"))
+                .to_str()
+                .unwrap()
+                .to_string();
+
+            get_file_content(Source::File(file), Some(name))
+        }
+        Source::File(file) => {
+            // Wrap the file in a BufReader to recurse with Source::Stream
+            let reader = BufReader::new(file);
+            let stream = Box::new(reader);
+
+            get_file_content(
+                Source::Stream(stream),
+                Some(name.unwrap_or_else(|| "New TextGrid".to_string())),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_input {
+    use std::io::Cursor;
+
+    use crate::input;
+
+    #[test]
+    fn get_file_content() {
+        let content = "xmin = 0\nxmax = 10";
+        let source = input::Source::Stream(Box::new(Cursor::new(content)));
+        let (content, name) = input::get_file_content(source, None).unwrap();
+        let expected_content = vec!["xmin = 0".to_string(), "xmax = 10".to_string()];
+        let expected_name = "New TextGrid".to_string();
+        assert_eq!(content, expected_content);
+        assert_eq!(name, expected_name);
+    }
+
+    #[test]
+    fn utf16() {
+        let content =
+            input::get_file_content(input::Source::Path("./example/utf16.TextGrid".into()), None)
+                .unwrap()
+                .0;
+        let expected_content =
+            input::get_file_content(input::Source::Path("./example/long.TextGrid".into()), None)
+                .unwrap()
+                .0;
+
+        assert_eq!(content, expected_content);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,10 @@ pub mod point;
 pub mod textgrid;
 mod utilities;
 
-use input::Source;
+use input::{get_file_content, Source};
 use interval::{Interval, Tier as IntervalTier};
 use point::{Point, Tier as PointTier};
 use textgrid::{TextGrid, Tier};
-use utilities::get_file_content;
 
 /// Parses a Praat `.TextGrid` file into a `textgridde::Textgrid` struct.
 ///

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,14 +1,13 @@
 use std::{
     collections::VecDeque,
-    fs::File,
-    io::{BufReader, Error, ErrorKind, Read, Result},
-    path::PathBuf,
+    io::{Error, ErrorKind, Result},
+    sync::LazyLock,
 };
 
-use encoding_rs::Encoding;
 use regex::Regex;
 
-use crate::input::Source;
+static NEXT_NUMBER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d+(\.\d+)?").unwrap());
+static QUOTED_STRING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#""[^"]*"|\S+"#).unwrap());
 
 /// Pull the next number from the `VecDeque` of `String`s.
 ///
@@ -23,10 +22,8 @@ pub fn pull_next_number<T>(textgrid_data: &mut VecDeque<String>) -> Result<T>
 where
     T: std::str::FromStr,
 {
-    let re = Regex::new(r"\d+(\.\d+)?").unwrap(); // Unwrap is safe here
-
     while let Some(line) = textgrid_data.pop_front() {
-        if let Some(captures) = re.captures(&line) {
+        if let Some(captures) = NEXT_NUMBER_RE.captures(&line) {
             if let Some(matched) = captures.get(0) {
                 return matched.as_str().to_string().parse::<T>().map_err(|_| {
                     Error::new(
@@ -92,9 +89,7 @@ pub fn process_lines(lines: &[String]) -> Vec<String> {
 ///
 /// A vector of strings split by spaces, but keeping quoted strings together.
 fn split_line_with_regex(line: &str) -> Vec<String> {
-    // Combined regex to split spaces not within quotes
-    let re = Regex::new(r#""[^"]*"|\S+"#).unwrap();
-    let split = re
+    let split = QUOTED_STRING_RE
         .captures_iter(line)
         .flat_map(|captures| {
             captures
@@ -107,85 +102,10 @@ fn split_line_with_regex(line: &str) -> Vec<String> {
     split
 }
 
-/// Gets the content of a file or stream.
-///
-/// # Arguments
-///
-/// * `source` - One of the following:
-///     * `Source::StringVector` - A vector of strings (what every other source is converted to).
-///     * `Source::Stream` - A stream of text (what path/file is converted to).
-///     * `Source::String` - A string that may be a path to a file or the content itself.
-///     * `Source::Path` - A path to a file.
-///     * `Source::File` - A file.
-/// * `name` - The file name; only passed during recursion.
-///
-/// # Returns
-///
-/// A `Result` containing a tuple of a vector of strings and a string if successful, or an `std::io::Error` if parsing failed.
-pub fn get_file_content(source: Source, name: Option<String>) -> Result<(Vec<String>, String)> {
-    match source {
-        Source::StringVector(string_vector) => {
-            Ok((string_vector, name.unwrap_or("New TextGrid".to_string())))
-        }
-        Source::String(string) => {
-            if PathBuf::from(&string).is_file() {
-                return get_file_content(Source::Path(string.into()), None);
-            }
-            let content = string
-                .split('\n')
-                .map(std::string::ToString::to_string)
-                .collect::<Vec<String>>();
-            let name = "New TextGrid".to_string();
-
-            get_file_content(Source::StringVector(content), Some(name))
-        }
-        Source::Stream(mut stream) => {
-            // Use encoding_rs to detect the BOM and convert to UTF-8 if necessary, since TextGrid files can sometimes be encoded in UTF-16.
-
-            let mut buffer = Vec::new();
-            stream.read_to_end(&mut buffer)?;
-
-            let (encoding, _) = Encoding::for_bom(&buffer).unwrap_or((encoding_rs::UTF_8, 0));
-            let content = encoding.decode(&buffer).0;
-
-            let content = content
-                .split('\n')
-                .map(std::string::ToString::to_string)
-                .collect::<Vec<String>>();
-
-            get_file_content(
-                Source::StringVector(content),
-                Some(name.unwrap_or("New TextGrid".to_string())),
-            )
-        }
-        Source::Path(path) => {
-            let file = File::open(path.clone())?;
-            let name = path
-                .file_name()
-                .unwrap_or_else(|| std::ffi::OsStr::new("New Textgrid"))
-                .to_str()
-                .unwrap()
-                .to_string();
-
-            get_file_content(Source::File(file), Some(name))
-        }
-        Source::File(file) => {
-            // Wrap the file in a BufReader to recurse with Source::Stream
-            let reader = BufReader::new(file);
-            let stream = Box::new(reader);
-
-            get_file_content(
-                Source::Stream(stream),
-                Some(name.unwrap_or_else(|| "New TextGrid".to_string())),
-            )
-        }
-    }
-}
-
 #[cfg(test)]
 mod test_utilities {
-    use crate::{input::Source, utilities};
-    use std::{collections::VecDeque, io::Cursor};
+    use crate::utilities;
+    use std::collections::VecDeque;
 
     #[test]
     fn pull_next_number() {
@@ -214,24 +134,5 @@ mod test_utilities {
         ];
         let expected = vec!["three four", "1", "2", "3.4", "5"];
         assert_eq!(utilities::process_lines(&lines), expected);
-    }
-
-    #[test]
-    fn get_file_content() {
-        let content = "xmin = 0\nxmax = 10";
-        let source = Source::Stream(Box::new(Cursor::new(content)));
-        let (content, name) = utilities::get_file_content(source, None).unwrap();
-        let expected_content = vec!["xmin = 0".to_string(), "xmax = 10".to_string()];
-        let expected_name = "New TextGrid".to_string();
-        assert_eq!(content, expected_content);
-        assert_eq!(name, expected_name);
-    }
-
-    #[test]
-    fn utf16() {
-        let content = utilities::get_file_content(Source::Path("./example/utf16.TextGrid".into()), None).unwrap().0;
-        let expected_content = utilities::get_file_content(Source::Path("./example/long.TextGrid".into()), None).unwrap().0;
-
-        assert_eq!(content, expected_content);
     }
 }


### PR DESCRIPTION
Since the regex for loading quoted strings/numbers was compiled every time they were needed, the performance was awful. Fixed that.

Changes:
- Moved `get_file_contents` from `utilities.rs` to `input.rs`, where it objectively belongs
- Compiled the regex in `utilities.rs`